### PR TITLE
feature get products by location

### DIFF
--- a/bangazon_api/models/store.py
+++ b/bangazon_api/models/store.py
@@ -10,3 +10,4 @@ class Store(models.Model):
 
     def __str__(self):
         return self.name
+ 

--- a/bangazon_api/views/product_view.py
+++ b/bangazon_api/views/product_view.py
@@ -160,13 +160,13 @@ class ProductView(ViewSet):
     def list(self, request):
         """Get a list of all products"""
         products = Product.objects.all()
-
         number_sold = request.query_params.get('number_sold', None)
         category = request.query_params.get('category', None)
         order = request.query_params.get('order_by', None)
         direction = request.query_params.get('direction', None)
         name = request.query_params.get('name', None)
-
+        location = request.query_params.get('location', None)
+        
         if number_sold:
             products = products.annotate(
                 order_count=Count('orders')
@@ -181,6 +181,9 @@ class ProductView(ViewSet):
 
         if name is not None:
             products = products.filter(name__icontains=name)
+
+        if location is not None:
+            products = products.filter(location=location)
 
         serializer = ProductSerializer(products, many=True)
         return Response(serializer.data)

--- a/db.session.sql
+++ b/db.session.sql
@@ -1,0 +1,6 @@
+select location
+from bangazon_api_product
+where location = 'Arizona'
+
+select *
+from bangazon_api_product

--- a/tests/test_product.py
+++ b/tests/test_product.py
@@ -75,3 +75,10 @@ class ProductTests(APITestCase):
         response = self.client.get('/api/products')
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(len(response.data), Product.objects.count())
+
+    def test_filtering_by_location(self):
+        """
+        Ensure we can filter by location query parameter
+        """
+
+        


### PR DESCRIPTION
When the client performs a GET request to the products resource, a query string parameter of location should be supported to get all products whose location property contains the value of the query string parameter.

Investigate the __contains filtering mechanism.